### PR TITLE
using only boost code headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,7 @@ set(Boost_ADDITIONAL_VERSIONS
     "1.60.0" "1.60" "1.61.0" "1.61" "1.62.0" "1.62" "1.63.0" "1.63" "1.64.0" "1.64"
     "1.65.0" "1.65" "1.66.0" "1.66" "1.67.0" "1.67" "1.68.0" "1.68" "1.69.0" "1.69"
 )
+add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY)
 find_package(Boost "1.35" COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
 
 if(Boost_FOUND)


### PR DESCRIPTION
The build fails on Ubuntu 20.04-4 when compiling with:

> undefined reference to boost::system::system_category()

The [stack overflow solution](https://stackoverflow.com/questions/9723793/undefined-reference-to-boostsystemsystem-category-when-compiling/50146757#50146757) fixes it.