### PR TITLE
Enable specifying target architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,12 +107,14 @@ option(ENABLE_ALL_TEST       "Enable all unit/component test"           OFF)
 # (gcc-ar, gcc-nm, ...).
 option(BUILD_WITH_LTO        "Enable LTO (experimental)"                OFF)
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
-  set(GCC_ARCH armv8-a CACHE STRING "GCC compile for specific architecture.")
-  message(STATUS "Detected aarch64 processor")
-else(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
-  set(GCC_ARCH native CACHE STRING "GCC compile for specific architecture.")
-endif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
+if(NOT GCC_ARCH)
+  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
+    set(GCC_ARCH armv8-a CACHE STRING "GCC compile for specific architecture.")
+    message(STATUS "Detected aarch64 processor")
+  else(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
+    set(GCC_ARCH native CACHE STRING "GCC compile for specific architecture.")
+  endif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
+endif()
 
 # On RAM constrained (embedded) systems it may be useful to limit parallel compilation with, e.g. -DPARALLEL_COMPILE_JOBS=1
 if (PARALLEL_COMPILE_JOBS)


### PR DESCRIPTION
The current configuration for on anything that is not `aarch64` will use the `native` architecture. This is completely fine when srsRAN is built on the machine where it will run, but problematic for packaging. The `native` architecture will let the compiler optimize for the exact CPU it is running on, including all available features. For example, if srsRAN is built on a CPU with `AVX-512` support, the final build will use `AVX-512`, even if the flag `-DHAVE_AVX512=False` is specified. In that case, the binary will not run on any CPU without `AVX-512`.

This PR keeps the default behaviour, so the instructions to build locally will still work properly and give an optimized build. However, if a specific architecture is passed to the cmake command like:

`cmake -S src -B build -DGCC_ARCH=x86_64`

It will override that behaviour and make a more generic binary. This will be useful for packagers like us, but could also be included in the official packages to make them more widely available.