### PR TITLE
FIX: Changed EPS bearer id validation

### DIFF
--- a/lib/include/srsran/common/common_lte.h
+++ b/lib/include/srsran/common/common_lte.h
@@ -60,8 +60,15 @@ const uint32_t MAX_LTE_SRB_ID = 2;
 enum class lte_drb { drb1 = 1, drb2, drb3, drb4, drb5, drb6, drb7, drb8, drb9, drb10, drb11, invalid };
 const uint32_t MAX_LTE_DRB_ID        = 11;
 const uint32_t MAX_LTE_LCID          = 10; // logicalChannelIdentity 3..10 in TS 36.331 v15.3
+const uint32_t MAX_EPS_BEARER_ID     = 15; // EPS Bearer ID range [5, 15] in 36 413
+const uint32_t MIN_EPS_BEARER_ID     = 5;
 const uint32_t INVALID_LCID          = 99; // random invalid LCID
 const uint32_t INVALID_EPS_BEARER_ID = 99; // random invalid eps bearer id
+
+constexpr bool is_eps_bearer_id(uint32_t eps_bearer_id)
+{
+  return  eps_bearer_id >= MIN_EPS_BEARER_ID and eps_bearer_id <= MAX_EPS_BEARER_ID;
+}
 
 constexpr bool is_lte_rb(uint32_t lcid)
 {

--- a/srsenb/src/stack/upper/gtpu.cc
+++ b/srsenb/src/stack/upper/gtpu.cc
@@ -66,7 +66,7 @@ gtpu_tunnel_manager::ue_bearer_tunnel_list* gtpu_tunnel_manager::find_rnti_tunne
 srsran::span<gtpu_tunnel_manager::bearer_teid_pair>
 gtpu_tunnel_manager::find_rnti_bearer_tunnels(uint16_t rnti, uint32_t eps_bearer_id)
 {
-  if (not is_lte_rb(eps_bearer_id)) {
+  if (not is_eps_bearer_id(eps_bearer_id)) {
     logger.warning("Searching for bearer with invalid eps-BearerID=%d", eps_bearer_id);
     return {};
   }
@@ -83,7 +83,7 @@ gtpu_tunnel_manager::find_rnti_bearer_tunnels(uint16_t rnti, uint32_t eps_bearer
 const gtpu_tunnel*
 gtpu_tunnel_manager::add_tunnel(uint16_t rnti, uint32_t eps_bearer_id, uint32_t teidout, uint32_t spgw_addr)
 {
-  if (not is_lte_rb(eps_bearer_id)) {
+  if (not is_eps_bearer_id(eps_bearer_id)) {
     logger.warning("Adding TEID with invalid eps-BearerID=%d", eps_bearer_id);
     return nullptr;
   }


### PR DESCRIPTION
When receiving a bearer activation request from MME, the eNB logs the following trace:

```2023-03-07T17:08:52.177759 [GTPU   ] [W] Adding TEID with invalid eps-BearerID=11
2023-03-07T17:08:52.177760 [RRC    ] [E] Adding erab_id=11 to GTPU
2023-03-07T17:08:52.177761 [RRC    ] [E] Adding erab_id=11 to GTPU
2023-03-07T17:08:52.177762 [GTPU   ] [W] Searching for bearer with invalid eps-BearerID=11
2023-03-07T17:08:52.177762 [GTPU   ] [I] Removing bearer rnti=0x46,eps-BearerID=11 without any active tunnels
2023-03-07T17:08:52.177764 [RRC    ] [E] Couldn't add E-RAB id=11 for rnti=0x46
```
As you can see, the eNB does not activate a dedicated EPS bearer, responding to the MME with an S1AP message "Radio-Resources not available" once the E-RAB ID is equals or greater than 11. 

In TS 36 413 the E-RAB-ID is defined in the range [0, 15].
- [0,4] reserved.
- [5, 15] available. 
