### PR TITLE
get_rsrp fix for TX-port

### DIFF
--- a/lib/src/phy/ch_estimation/chest_dl.c
+++ b/lib/src/phy/ch_estimation/chest_dl.c
@@ -928,7 +928,7 @@ static float get_rsrp_neighbour_port(srsran_chest_dl_t* q, uint32_t port)
 static float get_rsrp(srsran_chest_dl_t* q)
 {
   float max = -1e9;
-  for (int i = 0; i < q->nof_rx_antennas; ++i) {
+  for (int i = 0; i < q->cell.nof_ports; ++i) {
     float v = get_rsrp_port(q, i);
     if (v > max) {
       max = v;


### PR DESCRIPTION
Fixed what I'm assuming was a typo in the `get_rsrp()` function. It now finds the maximum RSRP from the TX antenna ports, rather than the RX antenna. 

`get_rsrp()` (line 928 of chest_dl.c) now loops through the number of TX antenna ports and returns the maximum RSRP from get_rsrp_port(). 

`get_rsrp_port()` (line 900 of chest_dl.c) loops through the RX-antenna RSRP and returns the average. 

The RSRP values come from a 2D array `q->rsrp[RX_antenna][TX_port]`. 

Because the variable _i_ (in get_rsrp) ends up being used as q->rsrp[...][i], leads me to believe the fix to TX antenna port is correct.

Thanks,
Max


