### PR TITLE
rf_blade: be explicit about 64-bit numbers in format strings

### DIFF
--- a/lib/src/phy/ch_estimation/chest_dl.c
+++ b/lib/src/phy/ch_estimation/chest_dl.c
@@ -928,7 +928,7 @@ static float get_rsrp_neighbour_port(srsran_chest_dl_t* q, uint32_t port)
 static float get_rsrp(srsran_chest_dl_t* q)
 {
   float max = -1e9;
-  for (int i = 0; i < q->nof_rx_antennas; ++i) {
+  for (int i = 0; i < q->cell.nof_ports; ++i) {
     float v = get_rsrp_port(q, i);
     if (v > max) {
       max = v;

--- a/lib/src/phy/rf/rf_blade_imp.c
+++ b/lib/src/phy/rf/rf_blade_imp.c
@@ -372,7 +372,7 @@ double rf_blade_set_rx_freq(void* h, UNUSED uint32_t ch, double freq)
   }
   f_int = 0;
   bladerf_get_frequency(handler->dev, BLADERF_RX_X1, &f_int);
-  printf("set RX frequency to %lu\n", f_int);
+  printf("set RX frequency to %llu\n", f_int);
 
   return freq;
 }
@@ -389,7 +389,7 @@ double rf_blade_set_tx_freq(void* h, UNUSED uint32_t ch, double freq)
 
   f_int = 0;
   bladerf_get_frequency(handler->dev, BLADERF_TX_X1, &f_int);
-  printf("set TX frequency to %lu\n", f_int);
+  printf("set TX frequency to %llu\n", f_int);
   return freq;
 }
 


### PR DESCRIPTION
bladerf_frequency is a 64-bit number. Change format strings to use %llu (long long unsigned int) as per the [code guide].

[code guide]: https://docs.srsran.com/projects/project/en/latest/dev_guide/source/code_guide/source/5_recommendations.html#fixed-width-integer-types

Fixes #1179.