### PR TITLE
Change not to include NSSAI IE in cleartext IEs in Registration Request.

### DIFF
--- a/srsue/src/stack/upper/nas_5g.cc
+++ b/srsue/src/stack/upper/nas_5g.cc
@@ -278,12 +278,6 @@ int nas_5g::send_registration_request()
   reg_req.ue_security_capability_present = true;
   fill_security_caps(reg_req.ue_security_capability);
 
-  if (cfg.enable_slicing) {
-    reg_req.requested_nssai_present = true;
-    s_nssai_t nssai;
-    set_nssai(nssai);
-    reg_req.requested_nssai.s_nssai_list.push_back(nssai);
-  }
   if (initial_registration_request_stored.pack(pdu) != SRSASN_SUCCESS) {
     logger.error("Failed to pack registration request");
     return SRSRAN_ERROR;


### PR DESCRIPTION
When using `srsue` by adding `[slicing]` section to `ue.conf` as NR-UE, change not to include NSSAI IE in `Plain NAS 5GS Message` of `InitialUEMessage` according to the following specifications.

`3GPP TS 24.501 (v17.8.0) - 4.4.6 Protection of initial NAS signalling messages`
```
When the initial NAS message is a REGISTRATION REQUEST message, the cleartext IEs are:

- Extended protocol discriminator;
- Security header type;
- Spare half octet;
- Registration request message identity;
- 5GS registration type;
- ngKSI;
- 5GS mobile identity;
- UE security capability;
- Additional GUTI;
- UE status;
- EPS NAS message container;
- NID; and
- PLMN with disaster condition.
```