### PR TITLE
fix nr::cc_worker::read_pdsch_d

### DIFF
--- a/srsue/src/phy/nr/cc_worker.cc
+++ b/srsue/src/phy/nr/cc_worker.cc
@@ -708,7 +708,7 @@ bool cc_worker::work_ul()
 
 int cc_worker::read_pdsch_d(cf_t* pdsch_d)
 {
-  uint32_t nof_re = ue_dl.carrier.nof_prb * SRSRAN_NRE * 12;
+  uint32_t nof_re = ue_dl.carrier.nof_prb * SRSRAN_NRE;
   srsran_vec_cf_copy(pdsch_d, ue_dl.pdsch.d[0], nof_re);
   return nof_re;
 }


### PR DESCRIPTION
I'm trying to use srsGUI in NR srsue, and I find the gui is not refreshed correctly (after adding a few lines needed to draw the gui). There are pixel points left over from previous times.

SRSRAN_NRE is expanded to 12 and it seems that the multiplication is done twice.

The issue is fixed after I make this change.