### PR TITLE
Fix out-of-bounds write with reset_measurements(SRSRAN_MAX_CARRIERS)

### DIFF
--- a/srsue/src/phy/phy_common.cc
+++ b/srsue/src/phy/phy_common.cc
@@ -655,6 +655,7 @@ void phy_common::reset_measurements(uint32_t cc_idx)
     for (uint32_t cc = 0; cc < SRSRAN_MAX_CARRIERS; cc++) {
       reset_measurements(cc);
     }
+    return;
   }
 
   // Default all metrics to NAN to prevent providing invalid information on traces and other layers


### PR DESCRIPTION
Fix `phy_common::reset_measurements` out of bounds writes when `cc_idx cc_idx >= SRSRAN_MAX_CARRIERS`

This case is hit when `phy_common::reset()` is called.

Possibly fixes #1295 as well.
