### PR TITLE
NAS 5G: Fix possible type confusion on GUTI dereference

### DIFF
--- a/srsue/src/stack/upper/nas_5g.cc
+++ b/srsue/src/stack/upper/nas_5g.cc
@@ -808,7 +808,7 @@ int nas_5g::handle_registration_accept(registration_accept_t& registration_accep
 
   bool send_reg_complete = false;
   logger.info("Handling Registration Accept");
-  if (registration_accept.guti_5g_present) {
+  if (registration_accept.guti_5g_present && registration_accept.guti_5g.type() == mobile_identity_5gs_t::guti_5g_type) {
     guti_5g           = registration_accept.guti_5g.guti_5g();
     send_reg_complete = true;
   }


### PR DESCRIPTION
Although TS 24.501 states this field “may be included to assign a 5G-GUTI to a UE”, it is typed  as 5GS mobile identity and may contain other values like SUPI or IMEI. This assumption leads to type confusion and a memory safety violation, ultimately leading to denial of service.